### PR TITLE
Load homepage faster

### DIFF
--- a/src/injected/homepage.tsx
+++ b/src/injected/homepage.tsx
@@ -2,7 +2,7 @@ import { createRoot } from "react-dom/client";
 import React from "react";
 import {
   getFavorites,
-  getForumLastPosts,
+  getForumLastThreads,
   getForums,
   getLastNews,
   getUserLastPosts,
@@ -13,11 +13,11 @@ import { hideContent, showContent } from "./utils/loader";
 
 export const injectHomepage = async () => {
   hideContent();
-  const [forums, favorites, lastPosts, lastNews, userLastsPosts] =
+  const [forums, favorites, lastThreads, lastNews, userLastPosts] =
     await Promise.all([
       getForums(),
       getFavorites(),
-      getForumLastPosts(),
+      getForumLastThreads(),
       getLastNews(),
       getUserLastPosts(getUsername()),
     ]);
@@ -30,10 +30,10 @@ export const injectHomepage = async () => {
       <Home
         favorites={favorites}
         forums={forums}
-        lastThreads={lastPosts}
+        lastThreads={lastThreads}
         lastNews={lastNews}
-        userLastPosts={userLastsPosts}
-      />,
+        userLastPosts={userLastPosts}
+      />
     );
 
     // Small delay fix issue with mounted dom elements not being available immediately after

--- a/src/injected/homepage.tsx
+++ b/src/injected/homepage.tsx
@@ -3,15 +3,12 @@ import React from "react";
 import Home from "../react/site/home";
 import { hideContent, showContent } from "./utils/loader";
 
-export const injectHomepage = async () => {
+export const injectHomepage = () => {
   hideContent();
   const main = document.getElementById("main");
 
   if (main) {
     const root = createRoot(main);
     root.render(<Home onLoad={showContent} />);
-
-    // Small delay fix issue with mounted dom elements not being available immediately after
-    return new Promise((resolve) => setTimeout(resolve, 1));
   }
 };

--- a/src/injected/homepage.tsx
+++ b/src/injected/homepage.tsx
@@ -1,40 +1,15 @@
 import { createRoot } from "react-dom/client";
 import React from "react";
-import {
-  getFavorites,
-  getForumLastThreads,
-  getForums,
-  getLastNews,
-  getUserLastPosts,
-  getUsername,
-} from "./utils/data";
 import Home from "../react/site/home";
 import { hideContent, showContent } from "./utils/loader";
 
 export const injectHomepage = async () => {
   hideContent();
-  const [forums, favorites, lastThreads, lastNews, userLastPosts] =
-    await Promise.all([
-      getForums(),
-      getFavorites(),
-      getForumLastThreads(),
-      getLastNews(),
-      getUserLastPosts(getUsername()),
-    ]);
-  showContent();
-
   const main = document.getElementById("main");
+
   if (main) {
     const root = createRoot(main);
-    root.render(
-      <Home
-        favorites={favorites}
-        forums={forums}
-        lastThreads={lastThreads}
-        lastNews={lastNews}
-        userLastPosts={userLastPosts}
-      />
-    );
+    root.render(<Home onLoad={showContent} />);
 
     // Small delay fix issue with mounted dom elements not being available immediately after
     return new Promise((resolve) => setTimeout(resolve, 1));

--- a/src/injected/index.tsx
+++ b/src/injected/index.tsx
@@ -50,7 +50,7 @@ window.ignite = {
     }
 
     if (isHomepage()) {
-      await injectHomepage();
+      injectHomepage();
     }
 
     if (isUserProfile()) {

--- a/src/injected/utils/data.ts
+++ b/src/injected/utils/data.ts
@@ -95,7 +95,7 @@ export const getFavorites = async (): Promise<Thread[]> => {
   return favorites;
 };
 
-export const getForumLastPosts = async (): Promise<Thread[]> => {
+export const getForumLastThreads = async (): Promise<Thread[]> => {
   const response = await fetch("https://www.mediavida.com/foro/spy", {
     headers: {
       accept: "*/*",

--- a/src/react/site/home/index.tsx
+++ b/src/react/site/home/index.tsx
@@ -1,24 +1,43 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 import Threads from "../components/threads";
 import { getIconClassBySlug } from "../utils/forums";
 import { useStore } from "../../../utils/store";
-import { getUsername } from "../../../injected/utils/data";
+import {
+  getFavorites,
+  getForumLastThreads,
+  getLastNews,
+  getUsername,
+  getUserLastPosts,
+} from "../../../injected/utils/data";
 import { Thread } from "../../../domains/thread";
 
-function Home({
-  favorites,
-  lastThreads,
-  lastNews,
-  userLastPosts,
-}: {
-  favorites: Thread[];
-  forums: { name: string; url: string; slug: string }[];
-  lastThreads: Thread[];
-  lastNews: Thread[];
-  userLastPosts: Thread[];
-}) {
+function Home({ onLoad }: { onLoad: () => void }) {
+  const [favorites, setFavorites] = useState<Thread[]>();
+  const [lastThreads, setLastThreads] = useState<Thread[]>();
+  const [lastNews, setLastNews] = useState<Thread[]>();
+  const [userLastPosts, setUserLastPosts] = useState<Thread[]>();
+
   const { forumsLastVisited } = useStore();
+
+  useEffect(() => {
+    const loadHomePageData = async () => {
+      const lastThreads = await getForumLastThreads();
+      setLastThreads(lastThreads);
+
+      const userLastPosts = await getUserLastPosts(getUsername());
+      setUserLastPosts(userLastPosts);
+
+      const favorites = await getFavorites();
+      setFavorites(favorites);
+
+      const lastNews = await getLastNews();
+      setLastNews(lastNews);
+    };
+
+    loadHomePageData();
+    onLoad();
+  }, []);
 
   return (
     <div className={clsx("py-2")}>
@@ -28,7 +47,7 @@ function Home({
       </div>
       <div className="mt-3 grid grid-cols-5 gap-2">
         {lastNews
-          .filter((_, i) => i < 5)
+          ?.filter((_, i) => i < 5)
           .map((thread) => {
             return (
               <div
@@ -50,7 +69,7 @@ function Home({
                       <i
                         className={clsx(
                           "fid",
-                          getIconClassBySlug(thread.forumSlug),
+                          getIconClassBySlug(thread.forumSlug)
                         )}
                       />
                     </a>
@@ -95,7 +114,7 @@ function Home({
             </div>
           </div>
           <Threads.Root className="mt-3">
-            {lastThreads.map((thread) => {
+            {lastThreads?.map((thread) => {
               return <Threads.Thread key={thread.url} {...thread} />;
             })}
           </Threads.Root>
@@ -107,7 +126,7 @@ function Home({
           </div>
           <Threads.Root className="mt-3">
             {userLastPosts
-              .filter((f, i) => i < 6)
+              ?.filter((f, i) => i < 6)
               .map((thread) => {
                 return <Threads.Thread key={thread.url} {...thread} />;
               })}
@@ -118,7 +137,7 @@ function Home({
           </div>
           <Threads.Root className="mt-3">
             {favorites
-              .filter((f, i) => f.responsesSinceLastVisit && i < 6)
+              ?.filter((f, i) => f.responsesSinceLastVisit && i < 6)
               .map((favorite) => {
                 return <Threads.Thread key={favorite.url} {...favorite} />;
               })}

--- a/src/react/site/home/index.tsx
+++ b/src/react/site/home/index.tsx
@@ -45,7 +45,7 @@ function Home({ onLoad }: { onLoad: () => void }) {
         <h1>Noticias</h1>
         <a href="/p2">Siguientes</a>
       </div>
-      <div className="mt-3 grid grid-cols-5 gap-2">
+      <div className="mt-3 grid grid-cols-5 gap-2 min-h-44">
         {lastNews
           ?.filter((_, i) => i < 5)
           .map((thread) => {
@@ -124,7 +124,7 @@ function Home({ onLoad }: { onLoad: () => void }) {
             <h2>Tus últimos posts </h2>
             <a href={`/id/${getUsername()}/posts`}>Todos</a>
           </div>
-          <Threads.Root className="mt-3">
+          <Threads.Root className="mt-3 min-h-72">
             {userLastPosts
               ?.filter((f, i) => i < 6)
               .map((thread) => {
@@ -135,7 +135,7 @@ function Home({ onLoad }: { onLoad: () => void }) {
             <h2>Favoritos</h2>
             <a href="/foro/favoritos">Todos</a>
           </div>
-          <Threads.Root className="mt-3">
+          <Threads.Root className="mt-3 min-h-72">
             {favorites
               ?.filter((f, i) => f.responsesSinceLastVisit && i < 6)
               .map((favorite) => {


### PR DESCRIPTION
Waiting for all the promises to finish makes the homepage to load a bit slow.
Re-rendering the page as data is resolved eases this issue. UX can be improved by working on something to smooth the flickering/blinking